### PR TITLE
style: revert back to 3:2 logo aspect ratio on mobile

### DIFF
--- a/src/app/medlemmer/page.tsx
+++ b/src/app/medlemmer/page.tsx
@@ -89,7 +89,7 @@ export default function Uses() {
               (activeButton === member.type || activeButton === '') && (
                 <li key={member.name}>
                   <Image
-                    className="w-full h-[120px] rounded-2xl object-contain"
+                    className="w-full h-[60vw] sm:h-[120px] rounded-2xl object-contain"
                     src={member.image()}
                     style={{
                       backgroundColor: member.logoBackgroundColor ?? "#ffffff",


### PR DESCRIPTION
Forgot to check mobile when creating https://github.com/offentlig-paas/nye.offentlig-paas.no/pull/43.

Revert mobile aspect ratio changes introduced in https://github.com/offentlig-paas/nye.offentlig-paas.no/pull/43, which changed height from a 3:2 ratio to hardcoded at 120px. 

## Before https://github.com/offentlig-paas/nye.offentlig-paas.no/pull/43

![image](https://github.com/user-attachments/assets/1dc247f0-1979-447d-b3bb-017b943c6caf)

## After https://github.com/offentlig-paas/nye.offentlig-paas.no/pull/43 (and https://github.com/offentlig-paas/nye.offentlig-paas.no/pull/44)

![image](https://github.com/user-attachments/assets/4692f5d5-7de9-49e8-8103-1f970af2e8cd)

## Now
![image](https://github.com/user-attachments/assets/5c3cee65-d50a-4175-94e8-0d6952d2868d)
