### PR TITLE
Removed unused dependency

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,3 @@
-import rehypePrism from '@mapbox/rehype-prism'
 import nextMDX from '@next/mdx'
 import remarkGfm from 'remark-gfm'
 
@@ -34,7 +33,6 @@ const withMDX = nextMDX({
   extension: /\.mdx?$/,
   options: {
     remarkPlugins: [remarkGfm],
-    rehypePlugins: [rehypePrism],
   },
 })
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "@headlessui/react": "^2.2.8",
     "@heroicons/react": "^2.2.0",
-    "@mapbox/rehype-prism": "^0.9.0",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
     "@next/mdx": "^15.5.2",


### PR DESCRIPTION
@mapbox/rehype-prism is never used (and it has a vulnerability that shows up in the security tab). 