### PR TITLE
Add import functionality for orphaned registrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "typecheck": "tsc --noEmit",
     "sanity": "sanity",
     "knip": "knip",
-    "knip:fix": "knip --fix"
+    "knip:fix": "knip --fix",
+    "postinstall": "simple-git-hooks"
   },
   "browserslist": "defaults, not ie <= 11",
   "dependencies": {
@@ -79,9 +80,13 @@
     "prettier": "^3.8.1",
     "prettier-plugin-tailwindcss": "^0.7.2",
     "sanity": "^5.20.0",
+    "simple-git-hooks": "^2.13.1",
     "tsx": "^4.21.0",
     "typescript-eslint": "^8.58.0",
     "vitest": "^4.1.2"
   },
-  "packageManager": "pnpm@10.24.0"
+  "packageManager": "pnpm@10.24.0",
+  "simple-git-hooks": {
+    "pre-commit": "pnpm run check"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
       sanity:
         specifier: ^5.20.0
         version: 5.20.0(@emotion/is-prop-valid@1.4.0)(@noble/hashes@2.0.1)(@oclif/core@4.10.3)(@sanity/cli-core@1.3.0(@noble/hashes@2.0.1)(@sanity/telemetry@0.9.0(react@19.2.4))(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(yaml@2.8.3))(@types/node@25.5.0)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(immer@11.1.4)(jiti@2.6.1)(lightningcss@1.32.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(styled-components@6.3.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(typescript@6.0.2)
+      simple-git-hooks:
+        specifier: ^2.13.1
+        version: 2.13.1
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -6717,6 +6720,10 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-git-hooks@2.13.1:
+    resolution: {integrity: sha512-WszCLXwT4h2k1ufIXAgsbiTOazqqevFCIncOuUBZJ91DdvWcC5+OFkluWRQPrcuSYd8fjq+o2y1QfWqYMoAToQ==}
+    hasBin: true
 
   simple-wcswidth@1.1.2:
     resolution: {integrity: sha512-j7piyCjAeTDSjzTSQ7DokZtMNwNlEAyxqSZeCS+CXH7fJ4jx3FuJ/mTW3mE+6JLs4VJBbcll0Kjn+KXI5t21Iw==}
@@ -15247,6 +15254,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  simple-git-hooks@2.13.1: {}
 
   simple-wcswidth@1.1.2: {}
 

--- a/src/components/AdminAttendeesClient.tsx
+++ b/src/components/AdminAttendeesClient.tsx
@@ -9,6 +9,7 @@ import { AdminRegistrationFilters } from '@/components/AdminRegistrationFilters'
 import { AdminEventActions } from '@/components/AdminEventActions'
 import { AdminEventStats } from '@/components/AdminEventStats'
 import { AddRegistrationModal } from '@/components/AddRegistrationModal'
+import { ImportRegistrationsModal } from '@/components/ImportRegistrationsModal'
 import {
   deleteRegistration,
   updateRegistrationStatus,
@@ -32,6 +33,7 @@ export function AdminAttendeesClient() {
   const [isDeleting, setIsDeleting] = useState<string | null>(null)
   const [isUpdatingStatus, setIsUpdatingStatus] = useState<string | null>(null)
   const [isAddModalOpen, setIsAddModalOpen] = useState(false)
+  const [isImportModalOpen, setIsImportModalOpen] = useState(false)
   const { showSuccess, showError } = useToast()
   const router = useRouter()
   const [_isPending, startTransition] = useTransition()
@@ -200,6 +202,7 @@ export function AdminAttendeesClient() {
         attendedCount={eventDetails.stats.statusBreakdown.attended || 0}
         onExport={handleExportCSV}
         onAddRegistration={() => setIsAddModalOpen(true)}
+        onImportRegistrations={() => setIsImportModalOpen(true)}
         onSuccess={message => showSuccess('Sendt', message)}
         onError={message => showError('Feil', message)}
         selectedCount={selectedRegistrations.length}
@@ -290,6 +293,19 @@ export function AdminAttendeesClient() {
         onSubmit={handleAddRegistration}
         hasSocialEvent={eventDetails.hasSocialEvent}
         attendanceTypes={eventDetails.registration.attendanceTypes}
+      />
+
+      <ImportRegistrationsModal
+        isOpen={isImportModalOpen}
+        onClose={() => setIsImportModalOpen(false)}
+        targetSlug={slug}
+        onSuccess={message => showSuccess('Importert', message)}
+        onError={message => showError('Feil', message)}
+        onImported={() => {
+          startTransition(() => {
+            router.refresh()
+          })
+        }}
       />
     </div>
   )

--- a/src/components/AdminEventActions.tsx
+++ b/src/components/AdminEventActions.tsx
@@ -6,6 +6,7 @@ import {
   ChatBubbleLeftRightIcon,
   DocumentArrowDownIcon,
   UserPlusIcon,
+  ArrowDownTrayIcon,
   XMarkIcon,
 } from '@heroicons/react/24/outline'
 import { SendReminderModal } from '@/components/SendReminderModal'
@@ -22,6 +23,7 @@ interface AdminEventActionsProps {
   attendedCount: number
   onExport?: () => void
   onAddRegistration?: () => void
+  onImportRegistrations?: () => void
   onSuccess?: (message: string) => void
   onError?: (message: string) => void
   showExport?: boolean
@@ -39,6 +41,7 @@ export function AdminEventActions({
   attendedCount,
   onExport,
   onAddRegistration,
+  onImportRegistrations,
   onSuccess,
   onError,
   showExport = true,
@@ -141,6 +144,16 @@ export function AdminEventActions({
               >
                 <UserPlusIcon className="mr-2 h-4 w-4" />
                 Legg til deltaker
+              </button>
+            )}
+
+            {onImportRegistrations && (
+              <button
+                onClick={onImportRegistrations}
+                className="inline-flex items-center rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors duration-150 hover:bg-zinc-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600 dark:focus:ring-offset-zinc-800"
+              >
+                <ArrowDownTrayIcon className="mr-2 h-4 w-4" />
+                Importer påmeldinger
               </button>
             )}
           </>

--- a/src/components/ImportRegistrationsModal.tsx
+++ b/src/components/ImportRegistrationsModal.tsx
@@ -1,0 +1,146 @@
+'use client'
+
+import { useState } from 'react'
+import {
+  ArrowDownTrayIcon,
+  ExclamationTriangleIcon,
+} from '@heroicons/react/24/outline'
+import { AdminModal } from '@/components/AdminModal'
+import { trpc } from '@/lib/trpc/client'
+import { Badge } from '@/components/Badge'
+
+interface ImportRegistrationsModalProps {
+  isOpen: boolean
+  onClose: () => void
+  targetSlug: string
+  onSuccess: (message: string) => void
+  onError: (message: string) => void
+  onImported: () => void
+}
+
+export function ImportRegistrationsModal({
+  isOpen,
+  onClose,
+  targetSlug,
+  onSuccess,
+  onError,
+  onImported,
+}: ImportRegistrationsModalProps) {
+  const [importingSlug, setImportingSlug] = useState<string | null>(null)
+
+  const {
+    data: orphanedGroups,
+    isLoading,
+    refetch,
+  } = trpc.admin.orphanedRegistrations.list.useQuery(undefined, {
+    enabled: isOpen,
+  })
+
+  const importMutation = trpc.admin.orphanedRegistrations.import.useMutation({
+    onSuccess: result => {
+      onSuccess(result.message)
+      setImportingSlug(null)
+      refetch()
+      onImported()
+    },
+    onError: err => {
+      onError(err.message)
+      setImportingSlug(null)
+    },
+  })
+
+  const handleImport = (fromSlug: string) => {
+    setImportingSlug(fromSlug)
+    importMutation.mutate({ slug: targetSlug, fromSlug })
+  }
+
+  return (
+    <AdminModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Importer påmeldinger"
+      description="Importer foreldreløse påmeldinger fra tidligere arrangementer som ikke lenger finnes."
+      icon={ArrowDownTrayIcon}
+      maxWidth="xl"
+    >
+      {isLoading && (
+        <p className="py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+          Laster…
+        </p>
+      )}
+
+      {!isLoading && (!orphanedGroups || orphanedGroups.length === 0) && (
+        <div className="flex flex-col items-center py-8 text-center">
+          <ExclamationTriangleIcon className="mb-2 h-8 w-8 text-zinc-400 dark:text-zinc-500" />
+          <p className="text-sm text-zinc-500 dark:text-zinc-400">
+            Ingen foreldreløse påmeldinger funnet
+          </p>
+        </div>
+      )}
+
+      {orphanedGroups && orphanedGroups.length > 0 && (
+        <div className="space-y-3">
+          {orphanedGroups.map(group => (
+            <div
+              key={group.eventSlug}
+              className="rounded-xl border border-zinc-200 p-4 dark:border-zinc-700"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <code className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                      {group.eventSlug}
+                    </code>
+                    <Badge color="yellow">{group.count} påmeldinger</Badge>
+                  </div>
+                  <div className="mt-2 space-y-1">
+                    {group.registrations.slice(0, 5).map(reg => (
+                      <p
+                        key={reg._id}
+                        className="truncate text-sm text-zinc-600 dark:text-zinc-400"
+                      >
+                        {reg.name}{' '}
+                        <span className="text-zinc-400 dark:text-zinc-500">
+                          ({reg.organisation})
+                        </span>
+                      </p>
+                    ))}
+                    {group.registrations.length > 5 && (
+                      <p className="text-sm text-zinc-400 dark:text-zinc-500">
+                        + {group.registrations.length - 5} til
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <button
+                  onClick={() => handleImport(group.eventSlug)}
+                  disabled={importingSlug !== null}
+                  className="inline-flex shrink-0 items-center rounded-xl bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors duration-150 hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-blue-700 dark:hover:bg-blue-600"
+                >
+                  {importingSlug === group.eventSlug ? (
+                    'Importerer…'
+                  ) : (
+                    <>
+                      <ArrowDownTrayIcon className="mr-2 h-4 w-4" />
+                      Importer hit
+                    </>
+                  )}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <div className="mt-4 flex justify-end">
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-xl border border-zinc-300 bg-white px-4 py-2 text-sm font-medium text-zinc-700 transition-colors hover:bg-zinc-50 dark:border-zinc-600 dark:bg-zinc-700 dark:text-zinc-300 dark:hover:bg-zinc-600"
+        >
+          Lukk
+        </button>
+      </div>
+    </AdminModal>
+  )
+}

--- a/src/domains/event-registration/__tests__/service.test.ts
+++ b/src/domains/event-registration/__tests__/service.test.ts
@@ -9,6 +9,12 @@ import type {
 } from '../types'
 
 vi.mock('../repository')
+vi.mock('@/lib/events/helpers', () => ({
+  getAllEvents: vi.fn(() => [
+    { slug: 'test-event' },
+    { slug: 'active-event' },
+  ]),
+}))
 
 describe('EventRegistrationService', () => {
   let service: EventRegistrationService
@@ -544,6 +550,172 @@ describe('EventRegistrationService', () => {
         ],
         'event-2': [{ ...mockRegistration, eventSlug: 'event-2' }],
       })
+    })
+  })
+
+  describe('getOrphanedRegistrationGroups', () => {
+    it('should return groups whose slugs do not match any known event', async () => {
+      mockRepository.getEventSlugCounts.mockResolvedValue([
+        { eventSlug: 'test-event', count: 3 },
+        { eventSlug: 'old-deleted-event', count: 2 },
+      ])
+      mockRepository.findMany.mockResolvedValue([
+        { ...mockRegistration, _id: 'r1', eventSlug: 'old-deleted-event' },
+        { ...mockRegistration, _id: 'r2', eventSlug: 'old-deleted-event' },
+      ])
+
+      const result = await service.getOrphanedRegistrationGroups()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.eventSlug).toBe('old-deleted-event')
+      expect(result[0]!.count).toBe(2)
+      expect(result[0]!.registrations).toHaveLength(2)
+    })
+
+    it('should exclude cancelled registrations from orphaned groups', async () => {
+      mockRepository.getEventSlugCounts.mockResolvedValue([
+        { eventSlug: 'orphan-slug', count: 2 },
+      ])
+      mockRepository.findMany.mockResolvedValue([
+        { ...mockRegistration, _id: 'r1', status: 'confirmed' as RegistrationStatus },
+        { ...mockRegistration, _id: 'r2', status: 'cancelled' as RegistrationStatus },
+      ])
+
+      const result = await service.getOrphanedRegistrationGroups()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]!.count).toBe(1)
+      expect(result[0]!.registrations).toHaveLength(1)
+    })
+
+    it('should return empty array when no orphaned registrations exist', async () => {
+      mockRepository.getEventSlugCounts.mockResolvedValue([
+        { eventSlug: 'test-event', count: 5 },
+      ])
+
+      const result = await service.getOrphanedRegistrationGroups()
+
+      expect(result).toHaveLength(0)
+    })
+
+    it('should filter out groups where all registrations are cancelled', async () => {
+      mockRepository.getEventSlugCounts.mockResolvedValue([
+        { eventSlug: 'orphan-slug', count: 1 },
+      ])
+      mockRepository.findMany.mockResolvedValue([
+        { ...mockRegistration, _id: 'r1', status: 'cancelled' as RegistrationStatus },
+      ])
+
+      const result = await service.getOrphanedRegistrationGroups()
+
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('importRegistrations', () => {
+    it('should reassign registrations from orphaned slug to target', async () => {
+      mockRepository.findMany
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'r1', eventSlug: 'orphan-slug', email: 'a@test.com', slackUserId: 'U001' },
+        ])
+        .mockResolvedValueOnce([])
+      mockRepository.reassignEventSlug.mockResolvedValue(1)
+
+      const result = await service.importRegistrations('orphan-slug', 'test-event')
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
+        'orphan-slug',
+        'test-event',
+        ['r1']
+      )
+    })
+
+    it('should skip duplicates by email', async () => {
+      mockRepository.findMany
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'r1', email: 'dup@test.com', slackUserId: 'U001' },
+          { ...mockRegistration, _id: 'r2', email: 'new@test.com', slackUserId: 'U002' },
+        ])
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'existing', email: 'dup@test.com', slackUserId: 'U003' },
+        ])
+      mockRepository.reassignEventSlug.mockResolvedValue(1)
+
+      const result = await service.importRegistrations('orphan-slug', 'test-event')
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(1)
+      expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
+        'orphan-slug',
+        'test-event',
+        ['r2']
+      )
+    })
+
+    it('should skip duplicates by slackUserId', async () => {
+      mockRepository.findMany
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'r1', email: 'new@test.com', slackUserId: 'U111' },
+        ])
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'existing', email: 'other@test.com', slackUserId: 'U111' },
+        ])
+      mockRepository.reassignEventSlug.mockResolvedValue(0)
+
+      const result = await service.importRegistrations('orphan-slug', 'test-event')
+
+      expect(result.imported).toBe(0)
+      expect(result.skipped).toBe(1)
+    })
+
+    it('should not skip when target has cancelled duplicate', async () => {
+      mockRepository.findMany
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'r1', email: 'a@test.com', slackUserId: 'U001', status: 'confirmed' as RegistrationStatus },
+        ])
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'existing', email: 'a@test.com', slackUserId: 'U002', status: 'cancelled' as RegistrationStatus },
+        ])
+      mockRepository.reassignEventSlug.mockResolvedValue(1)
+
+      const result = await service.importRegistrations('orphan-slug', 'test-event')
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(0)
+    })
+
+    it('should exclude cancelled source registrations', async () => {
+      mockRepository.findMany
+        .mockResolvedValueOnce([
+          { ...mockRegistration, _id: 'r1', email: 'a@test.com', slackUserId: 'U001', status: 'cancelled' as RegistrationStatus },
+          { ...mockRegistration, _id: 'r2', email: 'b@test.com', slackUserId: 'U002', status: 'confirmed' as RegistrationStatus },
+        ])
+        .mockResolvedValueOnce([])
+      mockRepository.reassignEventSlug.mockResolvedValue(1)
+
+      const result = await service.importRegistrations('orphan-slug', 'test-event')
+
+      expect(result.imported).toBe(1)
+      expect(result.skipped).toBe(0)
+      expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
+        'orphan-slug',
+        'test-event',
+        ['r2']
+      )
+    })
+
+    it('should throw when fromSlug equals toSlug', async () => {
+      await expect(
+        service.importRegistrations('test-event', 'test-event')
+      ).rejects.toThrow('Kan ikke importere påmeldinger til samme arrangement')
+    })
+
+    it('should throw when fromSlug is a known event', async () => {
+      await expect(
+        service.importRegistrations('active-event', 'test-event')
+      ).rejects.toThrow('Kan bare importere fra foreldreløse arrangementer')
     })
   })
 })

--- a/src/domains/event-registration/__tests__/service.test.ts
+++ b/src/domains/event-registration/__tests__/service.test.ts
@@ -10,10 +10,7 @@ import type {
 
 vi.mock('../repository')
 vi.mock('@/lib/events/helpers', () => ({
-  getAllEvents: vi.fn(() => [
-    { slug: 'test-event' },
-    { slug: 'active-event' },
-  ]),
+  getAllEvents: vi.fn(() => [{ slug: 'test-event' }, { slug: 'active-event' }]),
 }))
 
 describe('EventRegistrationService', () => {
@@ -577,8 +574,16 @@ describe('EventRegistrationService', () => {
         { eventSlug: 'orphan-slug', count: 2 },
       ])
       mockRepository.findMany.mockResolvedValue([
-        { ...mockRegistration, _id: 'r1', status: 'confirmed' as RegistrationStatus },
-        { ...mockRegistration, _id: 'r2', status: 'cancelled' as RegistrationStatus },
+        {
+          ...mockRegistration,
+          _id: 'r1',
+          status: 'confirmed' as RegistrationStatus,
+        },
+        {
+          ...mockRegistration,
+          _id: 'r2',
+          status: 'cancelled' as RegistrationStatus,
+        },
       ])
 
       const result = await service.getOrphanedRegistrationGroups()
@@ -603,7 +608,11 @@ describe('EventRegistrationService', () => {
         { eventSlug: 'orphan-slug', count: 1 },
       ])
       mockRepository.findMany.mockResolvedValue([
-        { ...mockRegistration, _id: 'r1', status: 'cancelled' as RegistrationStatus },
+        {
+          ...mockRegistration,
+          _id: 'r1',
+          status: 'cancelled' as RegistrationStatus,
+        },
       ])
 
       const result = await service.getOrphanedRegistrationGroups()
@@ -616,12 +625,21 @@ describe('EventRegistrationService', () => {
     it('should reassign registrations from orphaned slug to target', async () => {
       mockRepository.findMany
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'r1', eventSlug: 'orphan-slug', email: 'a@test.com', slackUserId: 'U001' },
+          {
+            ...mockRegistration,
+            _id: 'r1',
+            eventSlug: 'orphan-slug',
+            email: 'a@test.com',
+            slackUserId: 'U001',
+          },
         ])
         .mockResolvedValueOnce([])
       mockRepository.reassignEventSlug.mockResolvedValue(1)
 
-      const result = await service.importRegistrations('orphan-slug', 'test-event')
+      const result = await service.importRegistrations(
+        'orphan-slug',
+        'test-event'
+      )
 
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(0)
@@ -634,15 +652,33 @@ describe('EventRegistrationService', () => {
     it('should skip duplicates by email', async () => {
       mockRepository.findMany
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'r1', email: 'dup@test.com', slackUserId: 'U001' },
-          { ...mockRegistration, _id: 'r2', email: 'new@test.com', slackUserId: 'U002' },
+          {
+            ...mockRegistration,
+            _id: 'r1',
+            email: 'dup@test.com',
+            slackUserId: 'U001',
+          },
+          {
+            ...mockRegistration,
+            _id: 'r2',
+            email: 'new@test.com',
+            slackUserId: 'U002',
+          },
         ])
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'existing', email: 'dup@test.com', slackUserId: 'U003' },
+          {
+            ...mockRegistration,
+            _id: 'existing',
+            email: 'dup@test.com',
+            slackUserId: 'U003',
+          },
         ])
       mockRepository.reassignEventSlug.mockResolvedValue(1)
 
-      const result = await service.importRegistrations('orphan-slug', 'test-event')
+      const result = await service.importRegistrations(
+        'orphan-slug',
+        'test-event'
+      )
 
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(1)
@@ -655,14 +691,27 @@ describe('EventRegistrationService', () => {
     it('should skip duplicates by slackUserId', async () => {
       mockRepository.findMany
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'r1', email: 'new@test.com', slackUserId: 'U111' },
+          {
+            ...mockRegistration,
+            _id: 'r1',
+            email: 'new@test.com',
+            slackUserId: 'U111',
+          },
         ])
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'existing', email: 'other@test.com', slackUserId: 'U111' },
+          {
+            ...mockRegistration,
+            _id: 'existing',
+            email: 'other@test.com',
+            slackUserId: 'U111',
+          },
         ])
       mockRepository.reassignEventSlug.mockResolvedValue(0)
 
-      const result = await service.importRegistrations('orphan-slug', 'test-event')
+      const result = await service.importRegistrations(
+        'orphan-slug',
+        'test-event'
+      )
 
       expect(result.imported).toBe(0)
       expect(result.skipped).toBe(1)
@@ -671,14 +720,29 @@ describe('EventRegistrationService', () => {
     it('should not skip when target has cancelled duplicate', async () => {
       mockRepository.findMany
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'r1', email: 'a@test.com', slackUserId: 'U001', status: 'confirmed' as RegistrationStatus },
+          {
+            ...mockRegistration,
+            _id: 'r1',
+            email: 'a@test.com',
+            slackUserId: 'U001',
+            status: 'confirmed' as RegistrationStatus,
+          },
         ])
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'existing', email: 'a@test.com', slackUserId: 'U002', status: 'cancelled' as RegistrationStatus },
+          {
+            ...mockRegistration,
+            _id: 'existing',
+            email: 'a@test.com',
+            slackUserId: 'U002',
+            status: 'cancelled' as RegistrationStatus,
+          },
         ])
       mockRepository.reassignEventSlug.mockResolvedValue(1)
 
-      const result = await service.importRegistrations('orphan-slug', 'test-event')
+      const result = await service.importRegistrations(
+        'orphan-slug',
+        'test-event'
+      )
 
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(0)
@@ -687,13 +751,28 @@ describe('EventRegistrationService', () => {
     it('should exclude cancelled source registrations', async () => {
       mockRepository.findMany
         .mockResolvedValueOnce([
-          { ...mockRegistration, _id: 'r1', email: 'a@test.com', slackUserId: 'U001', status: 'cancelled' as RegistrationStatus },
-          { ...mockRegistration, _id: 'r2', email: 'b@test.com', slackUserId: 'U002', status: 'confirmed' as RegistrationStatus },
+          {
+            ...mockRegistration,
+            _id: 'r1',
+            email: 'a@test.com',
+            slackUserId: 'U001',
+            status: 'cancelled' as RegistrationStatus,
+          },
+          {
+            ...mockRegistration,
+            _id: 'r2',
+            email: 'b@test.com',
+            slackUserId: 'U002',
+            status: 'confirmed' as RegistrationStatus,
+          },
         ])
         .mockResolvedValueOnce([])
       mockRepository.reassignEventSlug.mockResolvedValue(1)
 
-      const result = await service.importRegistrations('orphan-slug', 'test-event')
+      const result = await service.importRegistrations(
+        'orphan-slug',
+        'test-event'
+      )
 
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(0)

--- a/src/domains/event-registration/__tests__/service.test.ts
+++ b/src/domains/event-registration/__tests__/service.test.ts
@@ -626,7 +626,6 @@ describe('EventRegistrationService', () => {
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(0)
       expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
-        'orphan-slug',
         'test-event',
         ['r1']
       )
@@ -648,7 +647,6 @@ describe('EventRegistrationService', () => {
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(1)
       expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
-        'orphan-slug',
         'test-event',
         ['r2']
       )
@@ -700,7 +698,6 @@ describe('EventRegistrationService', () => {
       expect(result.imported).toBe(1)
       expect(result.skipped).toBe(0)
       expect(mockRepository.reassignEventSlug).toHaveBeenCalledWith(
-        'orphan-slug',
         'test-event',
         ['r2']
       )

--- a/src/domains/event-registration/repository.ts
+++ b/src/domains/event-registration/repository.ts
@@ -188,9 +188,6 @@ export class EventRegistrationRepository {
     )
   }
 
-  /**
-   * Get all unique event slugs with their registration counts
-   */
   async getEventSlugCounts(): Promise<
     Array<{ eventSlug: string; count: number }>
   > {
@@ -212,19 +209,15 @@ export class EventRegistrationRepository {
     }))
   }
 
-  /**
-   * Reassign all registrations from one event slug to another
-   */
   async reassignEventSlug(
-    fromSlug: string,
     toSlug: string,
     registrationIds: string[]
   ): Promise<number> {
-    await Promise.all(
-      registrationIds.map(id =>
-        sanityClient.patch(id).set({ eventSlug: toSlug }).commit()
-      )
-    )
+    const transaction = sanityClient.transaction()
+    for (const id of registrationIds) {
+      transaction.patch(id, patch => patch.set({ eventSlug: toSlug }))
+    }
+    await transaction.commit()
     return registrationIds.length
   }
 

--- a/src/domains/event-registration/repository.ts
+++ b/src/domains/event-registration/repository.ts
@@ -189,6 +189,46 @@ export class EventRegistrationRepository {
   }
 
   /**
+   * Get all unique event slugs with their registration counts
+   */
+  async getEventSlugCounts(): Promise<
+    Array<{ eventSlug: string; count: number }>
+  > {
+    const query = groq`*[_type == "eventRegistration"]{ eventSlug }`
+    const results: Array<{ eventSlug: string }> = await sanityClient.fetch(
+      query,
+      {},
+      { cache: 'no-store', next: { revalidate: 0 } }
+    )
+
+    const counts = new Map<string, number>()
+    for (const r of results) {
+      counts.set(r.eventSlug, (counts.get(r.eventSlug) || 0) + 1)
+    }
+
+    return Array.from(counts.entries()).map(([eventSlug, count]) => ({
+      eventSlug,
+      count,
+    }))
+  }
+
+  /**
+   * Reassign all registrations from one event slug to another
+   */
+  async reassignEventSlug(
+    fromSlug: string,
+    toSlug: string,
+    registrationIds: string[]
+  ): Promise<number> {
+    await Promise.all(
+      registrationIds.map(id =>
+        sanityClient.patch(id).set({ eventSlug: toSlug }).commit()
+      )
+    )
+    return registrationIds.length
+  }
+
+  /**
    * Map Sanity document to domain type
    */
   private mapSanityToEventRegistration(

--- a/src/domains/event-registration/service.ts
+++ b/src/domains/event-registration/service.ts
@@ -430,7 +430,6 @@ export class EventRegistrationService {
     const skipped = activeSource.length - toImport.length
 
     await this.repository.reassignEventSlug(
-      fromSlug,
       toSlug,
       toImport.map(r => r._id!)
     )

--- a/src/domains/event-registration/service.ts
+++ b/src/domains/event-registration/service.ts
@@ -7,6 +7,20 @@ import type {
   EventRegistrationQuery,
   RegistrationStatus,
 } from './types'
+import { getAllEvents } from '@/lib/events/helpers'
+
+interface OrphanedRegistrationGroup {
+  eventSlug: string
+  count: number
+  registrations: Array<{
+    _id: string
+    name: string
+    email: string
+    organisation: string
+    status: RegistrationStatus
+    attendanceType?: string
+  }>
+}
 
 export class EventRegistrationService {
   private repository: EventRegistrationRepository
@@ -340,6 +354,88 @@ export class EventRegistrationService {
     )
 
     return registrations.length
+  }
+
+  async getOrphanedRegistrationGroups(): Promise<OrphanedRegistrationGroup[]> {
+    const slugCounts = await this.repository.getEventSlugCounts()
+    const knownSlugs = new Set(getAllEvents().map(e => e.slug))
+    const orphanedSlugs = slugCounts.filter(sc => !knownSlugs.has(sc.eventSlug))
+
+    const groups = await Promise.all(
+      orphanedSlugs.map(async ({ eventSlug }) => {
+        const registrations = await this.repository.findMany({ eventSlug })
+        const activeRegistrations = registrations.filter(
+          r => r.status !== 'cancelled'
+        )
+        return {
+          eventSlug,
+          count: activeRegistrations.length,
+          registrations: activeRegistrations.map(r => ({
+            _id: r._id!,
+            name: r.name,
+            email: r.email,
+            organisation: r.organisation,
+            status: r.status,
+            attendanceType: r.attendanceType,
+          })),
+        }
+      })
+    )
+
+    return groups.filter(g => g.count > 0)
+  }
+
+  async importRegistrations(
+    fromSlug: string,
+    toSlug: string
+  ): Promise<{ imported: number; skipped: number }> {
+    if (fromSlug === toSlug) {
+      throw new Error('Kan ikke importere påmeldinger til samme arrangement')
+    }
+
+    const knownSlugs = new Set(getAllEvents().map(e => e.slug))
+    if (knownSlugs.has(fromSlug)) {
+      throw new Error(
+        'Kan bare importere fra foreldreløse arrangementer som ikke lenger finnes'
+      )
+    }
+
+    const sourceRegistrations = await this.repository.findMany({
+      eventSlug: fromSlug,
+    })
+    const targetRegistrations = await this.repository.findMany({
+      eventSlug: toSlug,
+    })
+
+    const activeSource = sourceRegistrations.filter(
+      r => r.status !== 'cancelled'
+    )
+
+    const activeTargetEmails = new Set(
+      targetRegistrations
+        .filter(r => r.status !== 'cancelled')
+        .map(r => r.email.toLowerCase())
+    )
+    const activeTargetSlackIds = new Set(
+      targetRegistrations
+        .filter(r => r.status !== 'cancelled' && r.slackUserId)
+        .map(r => r.slackUserId!)
+    )
+
+    const toImport = activeSource.filter(r => {
+      if (activeTargetEmails.has(r.email.toLowerCase())) return false
+      if (r.slackUserId && activeTargetSlackIds.has(r.slackUserId)) return false
+      return true
+    })
+    const skipped = activeSource.length - toImport.length
+
+    await this.repository.reassignEventSlug(
+      fromSlug,
+      toSlug,
+      toImport.map(r => r._id!)
+    )
+
+    return { imported: toImport.length, skipped }
   }
 
   private validateRegistrationInput(input: CreateEventRegistrationInput): void {

--- a/src/server/routers/admin.ts
+++ b/src/server/routers/admin.ts
@@ -1,6 +1,7 @@
 import {
   router,
   protectedProcedure,
+  adminProcedure,
   createEventAccessMiddleware,
 } from '../trpc'
 import { z } from 'zod'
@@ -1067,6 +1068,37 @@ Mvh ${organizerNames}`
 
         await talkSubmissionService.deleteSubmission(input.submissionId)
         return { message: 'Forslag slettet' }
+      }),
+  }),
+
+  orphanedRegistrations: router({
+    list: adminProcedure.query(async () => {
+      return eventRegistrationService.getOrphanedRegistrationGroups()
+    }),
+
+    import: adminEventProcedure
+      .input(
+        z.object({
+          slug: z.string(),
+          fromSlug: z.string(),
+        })
+      )
+      .mutation(async ({ input }) => {
+        const result = await eventRegistrationService.importRegistrations(
+          input.fromSlug,
+          input.slug
+        )
+        const parts = []
+        if (result.imported > 0) {
+          parts.push(`${result.imported} påmeldinger importert`)
+        }
+        if (result.skipped > 0) {
+          parts.push(`${result.skipped} duplikater hoppet over`)
+        }
+        return {
+          ...result,
+          message: parts.join(', ') || 'Ingen påmeldinger å importere',
+        }
       }),
   }),
 

--- a/src/server/routers/admin.ts
+++ b/src/server/routers/admin.ts
@@ -1076,7 +1076,7 @@ Mvh ${organizerNames}`
       return eventRegistrationService.getOrphanedRegistrationGroups()
     }),
 
-    import: adminEventProcedure
+    import: adminProcedure
       .input(
         z.object({
           slug: z.string(),


### PR DESCRIPTION
Introduce functionality to import registrations from orphaned events, along with necessary UI components for managing this process. This enhancement allows for better handling of orphaned registrations within the application.